### PR TITLE
Fix backend security holes and replace stub implementations with working code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,58 @@ FRONTEND_URL=http://localhost:3000
 
 # Other Configuration
 API_PREFIX=/api
+PUBLIC_API_URL=http://localhost:5100
+BASE_URL=http://localhost:5100
+
+# Encryption (M-Pesa/config secrets at rest)
+ENCRYPTION_KEY=change_me_to_a_random_32_byte_value
+CONFIG_ENCRYPTION_KEY=change_me_to_a_random_32_byte_value
+
+# M-Pesa (Daraja) — required if a tenant does not configure their own via Superadmin
+MPESA_CONSUMER_KEY=
+MPESA_CONSUMER_SECRET=
+MPESA_SHORTCODE=
+MPESA_PASSKEY=
+MPESA_CALLBACK_URL=
+MPESA_ENVIRONMENT=sandbox
+# Secret used to HMAC-sign the token embedded in the M-Pesa callback URL. Required.
+MPESA_CALLBACK_SECRET=change_me_to_a_random_secret
+
+# Stripe (billing)
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_BASIC_PRICE_ID=
+STRIPE_PRO_PRICE_ID=
+STRIPE_ENTERPRISE_PRICE_ID=
+
+# OpenAI (AI features)
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_CHAT_MODEL=
+OPENAI_EMBEDDING_MODEL=
+OPENAI_EXTRACTOR_MODEL=
+
+# Swagger / API docs
+SWAGGER_ENABLED=true
+SWAGGER_PATH=/docs
+
+# File storage
+UPLOADS_DIR=./uploads
+POS_UPDATES_DIR=./pos-updates
+
+# Startup behavior
+SEED_PERMISSIONS_ON_STARTUP=false
+
+# reCAPTCHA (optional)
+RECAPTCHA_SECRET_KEY=
+
+# Support/notification email addresses
+ADMIN_EMAIL=
+SUPPORT_EMAIL=
+FROM_EMAIL=noreply@example.com
+
+# Alternate email transport (Gmail) — used instead of SMTP_* if USE_GMAIL=true
+USE_GMAIL=false
+GMAIL_USER=
+GMAIL_PASS=

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ backups/
 *.sql.gz
 *.bak
 *.backup
+
+# Bulk-admin data exports (contain tenant/user PII)
+exports/
+
+# Replication learning lab artifacts
+pgdata_standby/
+scripts/replication/logs/

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -24,6 +24,7 @@ import { AdminHealthController } from './admin-health.controller';
 import { PlatformSettingsController } from './platform-settings.controller';
 import { ImpersonationController } from './impersonation.controller';
 import { ClassificationModule } from '../classification/classification.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { ClassificationModule } from '../classification/classification.module';
     TenantConfigurationModule,
     MonitoringModule,
     ClassificationModule,
+    EmailModule,
   ],
   controllers: [
     AdminController,

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -21,6 +21,7 @@ export class AdminService {
     private readonly prisma: PrismaService,
     private readonly adminTenantStatsService: AdminTenantStatsService,
     private readonly tenantService: TenantService,
+    private readonly emailService: EmailService,
   ) {}
 
   private async getPhysicalProductCount(tenantId?: string): Promise<number> {
@@ -1025,8 +1026,6 @@ export class AdminService {
 
     // Send welcome email with login credentials
     try {
-      const emailService = new EmailService();
-
       const html = `
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
           <h2>Welcome to SaaS Platform!</h2>
@@ -1041,7 +1040,7 @@ export class AdminService {
         </div>
       `;
 
-      await emailService.sendPaymentConfirmationEmail(
+      this.emailService.sendPaymentConfirmationEmail(
         result.user.email,
         'Welcome to SaaS Platform - Your Account is Ready',
         html,

--- a/src/admin/bulk.controller.ts
+++ b/src/admin/bulk.controller.ts
@@ -32,14 +32,18 @@ export class BulkController {
       tenantIds?: string[];
       userIds?: string[];
       confirmation?: string;
+      planId?: string;
+      importFilename?: string;
     },
   ) {
-    const { action, tenantIds, userIds, confirmation } = body;
+    const { action, tenantIds, userIds, confirmation, planId, importFilename } =
+      body;
 
     const destructiveActions = [
       'suspend_users',
       'suspend_tenants',
       'delete_tenants',
+      'import_data',
     ];
     if (destructiveActions.includes(action) && confirmation !== 'CONFIRM') {
       throw new BadRequestException(
@@ -47,6 +51,9 @@ export class BulkController {
       );
     }
 
-    return this.bulkService.execute(action, tenantIds ?? [], userIds ?? []);
+    return this.bulkService.execute(action, tenantIds ?? [], userIds ?? [], {
+      planId,
+      importFilename,
+    });
   }
 }

--- a/src/admin/bulk.service.ts
+++ b/src/admin/bulk.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { promises as fs } from 'fs';
+import * as path from 'path';
 import { PrismaService } from '../prisma.service';
+import { AuthService } from '../auth/auth.services';
+import { SubscriptionAdminService } from './subscription-admin.service';
 
 export interface BulkOperation {
   id: string;
@@ -19,8 +23,17 @@ export class BulkService {
   private readonly logger = new Logger(BulkService.name);
   private operationsHistory: BulkOperation[] = [];
   private readonly MAX_HISTORY = 50;
+  private readonly exportsDir = path.join(process.cwd(), 'exports');
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly authService: AuthService,
+    private readonly subscriptionAdminService: SubscriptionAdminService,
+  ) {}
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Unknown error';
+  }
 
   getOperations(): BulkOperation[] {
     return [...this.operationsHistory].reverse();
@@ -43,7 +56,13 @@ export class BulkService {
     action: string,
     tenantIds: string[],
     userIds: string[],
-  ): Promise<{ success: boolean; message: string; affectedCount?: number }> {
+    options: { planId?: string; importFilename?: string } = {},
+  ): Promise<{
+    success: boolean;
+    message: string;
+    affectedCount?: number;
+    data?: unknown;
+  }> {
     const now = new Date().toISOString();
 
     switch (action) {
@@ -171,14 +190,285 @@ export class BulkService {
           message: 'Cache clear requested (no-op in current implementation)',
         };
 
-      case 'reset_passwords':
-      case 'update_plan':
-      case 'export_data':
-      case 'import_data':
-      case 'optimize_database':
-        throw new BadRequestException(
-          `Action '${action}' is not yet implemented. Available: suspend_tenants, activate_tenants, suspend_users, activate_users, clear_cache`,
+      case 'reset_passwords': {
+        if (!userIds.length) {
+          throw new BadRequestException(
+            'userIds array is required for reset_passwords',
+          );
+        }
+        const users = await this.prisma.user.findMany({
+          where: { id: { in: userIds } },
+          select: { id: true, email: true },
+        });
+        let sent = 0;
+        for (const u of users) {
+          try {
+            await this.authService.forgotPassword(u.email);
+            sent++;
+          } catch (error) {
+            this.logger.warn(
+              `Failed to queue password reset for ${u.email}: ${this.getErrorMessage(error)}`,
+            );
+          }
+        }
+        this.addToHistory({
+          type: 'user_management',
+          action: 'reset_passwords',
+          description: 'Send password reset emails to selected users',
+          affectedCount: sent,
+          status: 'completed',
+          progress: 100,
+          createdAt: now,
+          completedAt: now,
+        });
+        return {
+          success: true,
+          message: `Password reset email sent to ${sent} of ${userIds.length} user(s)`,
+          affectedCount: sent,
+        };
+      }
+
+      case 'update_plan': {
+        if (!tenantIds.length) {
+          throw new BadRequestException(
+            'tenantIds array is required for update_plan',
+          );
+        }
+        if (!options.planId) {
+          throw new BadRequestException('planId is required for update_plan');
+        }
+        let updated = 0;
+        const errors: string[] = [];
+        for (const tenantId of tenantIds) {
+          try {
+            await this.subscriptionAdminService.assignPlanToTenant(
+              tenantId,
+              options.planId,
+            );
+            updated++;
+          } catch (error) {
+            errors.push(`${tenantId}: ${this.getErrorMessage(error)}`);
+          }
+        }
+        this.addToHistory({
+          type: 'tenant_management',
+          action: 'update_plan',
+          description: `Assign plan ${options.planId} to selected tenants`,
+          affectedCount: updated,
+          status: errors.length ? 'failed' : 'completed',
+          progress: 100,
+          createdAt: now,
+          completedAt: now,
+          error: errors.length ? errors.join('; ') : undefined,
+        });
+        return {
+          success: updated > 0,
+          message: `Updated plan for ${updated} of ${tenantIds.length} tenant(s)${
+            errors.length ? `; ${errors.length} failed` : ''
+          }`,
+          affectedCount: updated,
+        };
+      }
+
+      case 'export_data': {
+        if (!tenantIds.length) {
+          throw new BadRequestException(
+            'tenantIds array is required for export_data',
+          );
+        }
+        const tenants = await this.prisma.tenant.findMany({
+          where: { id: { in: tenantIds } },
+          select: {
+            id: true,
+            name: true,
+            businessType: true,
+            contactEmail: true,
+            contactPhone: true,
+            address: true,
+            city: true,
+            country: true,
+            website: true,
+            vatNumber: true,
+            taxId: true,
+            currency: true,
+            timezone: true,
+            createdAt: true,
+          },
+        });
+
+        const users = await this.prisma.user.findMany({
+          where: { tenantId: { in: tenantIds } },
+          select: {
+            id: true,
+            tenantId: true,
+            email: true,
+            name: true,
+            isDisabled: true,
+            createdAt: true,
+          },
+        });
+
+        const [productCounts, saleCounts] = await Promise.all([
+          this.prisma.product.groupBy({
+            by: ['tenantId'],
+            where: { tenantId: { in: tenantIds } },
+            _count: { _all: true },
+          }),
+          this.prisma.sale.groupBy({
+            by: ['tenantId'],
+            where: { tenantId: { in: tenantIds } },
+            _count: { _all: true },
+          }),
+        ]);
+
+        const exportPayload = {
+          exportedAt: now,
+          tenants: tenants.map((t) => ({
+            ...t,
+            userCount: users.filter((u) => u.tenantId === t.id).length,
+            productCount:
+              productCounts.find((p) => p.tenantId === t.id)?._count._all ?? 0,
+            saleCount:
+              saleCounts.find((s) => s.tenantId === t.id)?._count._all ?? 0,
+          })),
+          users,
+        };
+
+        await fs.mkdir(this.exportsDir, { recursive: true });
+        const filename = `export-${Date.now()}.json`;
+        const filePath = path.join(this.exportsDir, filename);
+        await fs.writeFile(
+          filePath,
+          JSON.stringify(exportPayload, null, 2),
+          'utf8',
         );
+
+        this.addToHistory({
+          type: 'tenant_management',
+          action: 'export_data',
+          description: `Export data for ${tenants.length} tenant(s)`,
+          affectedCount: tenants.length,
+          status: 'completed',
+          progress: 100,
+          createdAt: now,
+          completedAt: now,
+        });
+
+        return {
+          success: true,
+          message: `Exported data for ${tenants.length} tenant(s) to ${filename}`,
+          affectedCount: tenants.length,
+          data: { filename },
+        };
+      }
+
+      case 'import_data': {
+        // Only re-applies safe, non-destructive tenant profile fields from a
+        // previous export_data run (never creates tenants/users or touches
+        // financial data) — a generic importer for an undefined external
+        // format would be a data-integrity and security risk.
+        if (!options.importFilename) {
+          throw new BadRequestException(
+            'importFilename is required for import_data (must reference a file produced by export_data)',
+          );
+        }
+        const filePath = path.join(this.exportsDir, options.importFilename);
+        const resolved = path.resolve(filePath);
+        if (!resolved.startsWith(path.resolve(this.exportsDir))) {
+          throw new BadRequestException('Invalid importFilename');
+        }
+
+        let payload: {
+          tenants?: Array<{
+            id: string;
+            name?: string;
+            contactEmail?: string;
+            contactPhone?: string;
+            address?: string;
+            city?: string;
+            country?: string;
+            website?: string;
+            vatNumber?: string;
+            taxId?: string;
+          }>;
+        };
+        try {
+          const raw = await fs.readFile(resolved, 'utf8');
+          payload = JSON.parse(raw) as typeof payload;
+        } catch (error) {
+          throw new BadRequestException(
+            `Failed to read export file: ${this.getErrorMessage(error)}`,
+          );
+        }
+
+        const tenants = payload.tenants ?? [];
+        let restored = 0;
+        for (const t of tenants) {
+          if (!t.id) continue;
+          try {
+            await this.prisma.tenant.update({
+              where: { id: t.id },
+              data: {
+                name: t.name,
+                contactEmail: t.contactEmail,
+                contactPhone: t.contactPhone,
+                address: t.address,
+                city: t.city,
+                country: t.country,
+                website: t.website,
+                vatNumber: t.vatNumber,
+                taxId: t.taxId,
+              },
+            });
+            restored++;
+          } catch (error) {
+            this.logger.warn(
+              `Failed to restore tenant ${t.id}: ${this.getErrorMessage(error)}`,
+            );
+          }
+        }
+
+        this.addToHistory({
+          type: 'tenant_management',
+          action: 'import_data',
+          description: `Restore tenant profile fields from ${options.importFilename}`,
+          affectedCount: restored,
+          status: 'completed',
+          progress: 100,
+          createdAt: now,
+          completedAt: now,
+        });
+
+        return {
+          success: true,
+          message: `Restored profile fields for ${restored} of ${tenants.length} tenant(s)`,
+          affectedCount: restored,
+        };
+      }
+
+      case 'optimize_database': {
+        try {
+          await this.prisma.$executeRawUnsafe('VACUUM ANALYZE');
+        } catch (error) {
+          throw new BadRequestException(
+            `Database optimization failed: ${this.getErrorMessage(error)}`,
+          );
+        }
+        this.addToHistory({
+          type: 'system_maintenance',
+          action: 'optimize_database',
+          description: 'Run VACUUM ANALYZE on the database',
+          affectedCount: 0,
+          status: 'completed',
+          progress: 100,
+          createdAt: now,
+          completedAt: now,
+        });
+        return {
+          success: true,
+          message: 'Database optimization (VACUUM ANALYZE) completed',
+        };
+      }
 
       default:
         throw new BadRequestException(`Unknown action: ${action}`);

--- a/src/adminTenantStats/admin-tenant-stats.controller.ts
+++ b/src/adminTenantStats/admin-tenant-stats.controller.ts
@@ -1,7 +1,11 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { AdminTenantStatsService } from './admin-tenant-stats.service';
+import { SuperadminGuard } from '../admin/superadmin.guard';
+import { TrialGuard } from '../auth/trial.guard';
 
 @Controller('admin/tenants/analytics')
+@UseGuards(AuthGuard('jwt'), SuperadminGuard, TrialGuard)
 export class AdminTenantStatsController {
   constructor(private readonly statsService: AdminTenantStatsService) {}
 

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -93,7 +93,10 @@ export class AnalyticsController {
     return tenantId;
   }
 
-  private rethrowKnownOrInternal(error: unknown, fallbackMessage: string): never {
+  private rethrowKnownOrInternal(
+    error: unknown,
+    fallbackMessage: string,
+  ): never {
     if (error instanceof HttpException) {
       throw error;
     }
@@ -326,6 +329,115 @@ export class AnalyticsController {
       this.rethrowKnownOrInternal(
         error,
         'Failed to fetch stockout lost sales report',
+      );
+    }
+  }
+
+  @Get('/analytics/inventory-movement')
+  @UseGuards(AuthGuard('jwt'), TrialGuard)
+  async getInventoryMovement(@Req() req: AuthenticatedRequest) {
+    const tenantId = this.requireTenantId(req);
+    const query = req.query as Record<string, unknown>;
+
+    try {
+      const effectiveBranchId = this.resolveBranchScope(req);
+      return await this.analyticsService.getInventoryMovement(
+        tenantId,
+        effectiveBranchId,
+        this.getString(query.from),
+        this.getString(query.to),
+      );
+    } catch (error) {
+      console.error('Error fetching inventory movement report:', error);
+      this.rethrowKnownOrInternal(
+        error,
+        'Failed to fetch inventory movement report',
+      );
+    }
+  }
+
+  @Get('/analytics/inventory-valuation')
+  @UseGuards(AuthGuard('jwt'), TrialGuard)
+  async getInventoryValuation(@Req() req: AuthenticatedRequest) {
+    const tenantId = this.requireTenantId(req);
+
+    try {
+      const effectiveBranchId = this.resolveBranchScope(req);
+      return await this.analyticsService.getInventoryValuation(
+        tenantId,
+        effectiveBranchId,
+      );
+    } catch (error) {
+      console.error('Error fetching inventory valuation report:', error);
+      this.rethrowKnownOrInternal(
+        error,
+        'Failed to fetch inventory valuation report',
+      );
+    }
+  }
+
+  @Get('/analytics/inventory-aging')
+  @UseGuards(AuthGuard('jwt'), TrialGuard)
+  async getInventoryAging(@Req() req: AuthenticatedRequest) {
+    const tenantId = this.requireTenantId(req);
+
+    try {
+      const effectiveBranchId = this.resolveBranchScope(req);
+      return await this.analyticsService.getInventoryAging(
+        tenantId,
+        effectiveBranchId,
+      );
+    } catch (error) {
+      console.error('Error fetching inventory aging report:', error);
+      this.rethrowKnownOrInternal(
+        error,
+        'Failed to fetch inventory aging report',
+      );
+    }
+  }
+
+  @Get('/analytics/inventory-turnover')
+  @UseGuards(AuthGuard('jwt'), TrialGuard)
+  async getInventoryTurnover(@Req() req: AuthenticatedRequest) {
+    const tenantId = this.requireTenantId(req);
+    const query = req.query as Record<string, unknown>;
+
+    try {
+      const effectiveBranchId = this.resolveBranchScope(req);
+      return await this.analyticsService.getInventoryTurnover(
+        tenantId,
+        effectiveBranchId,
+        this.getString(query.from),
+        this.getString(query.to),
+      );
+    } catch (error) {
+      console.error('Error fetching inventory turnover report:', error);
+      this.rethrowKnownOrInternal(
+        error,
+        'Failed to fetch inventory turnover report',
+      );
+    }
+  }
+
+  @Get('/analytics/product-category-analysis')
+  @UseGuards(AuthGuard('jwt'), TrialGuard)
+  async getProductCategoryAnalysis(@Req() req: AuthenticatedRequest) {
+    const tenantId = this.requireTenantId(req);
+    const query = req.query as Record<string, unknown>;
+
+    try {
+      const effectiveBranchId = this.resolveBranchScope(req);
+      return await this.analyticsService.getProductCategoryAnalysis(
+        tenantId,
+        effectiveBranchId,
+        this.getString(query.from),
+        this.getString(query.to),
+      );
+    } catch (error) {
+      console.error('Error fetching product category analysis report:', error);
+      this.rethrowKnownOrInternal(
+        error,
+        'Failed to fetch product category analysis report',
       );
     }
   }

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -54,9 +54,12 @@ export class AnalyticsService {
       endDate.length > 0;
 
     if (hasCustomRange) {
-      const parsedStart = new Date(startDate as string);
-      const parsedEnd = new Date(endDate as string);
-      if (!Number.isNaN(parsedStart.getTime()) && !Number.isNaN(parsedEnd.getTime())) {
+      const parsedStart = new Date(startDate);
+      const parsedEnd = new Date(endDate);
+      if (
+        !Number.isNaN(parsedStart.getTime()) &&
+        !Number.isNaN(parsedEnd.getTime())
+      ) {
         const normalizedStart = new Date(parsedStart);
         normalizedStart.setHours(0, 0, 0, 0);
 
@@ -290,42 +293,47 @@ export class AnalyticsService {
         ...(options.branchId ? { branchId: options.branchId } : {}),
       };
 
-      const [xReport, zReport, paymentMethodsRange, cashierRaw, todayCashierRaw] =
-        await Promise.all([
-          buildSnapshot(todayStart, now),
-          buildSnapshot(yesterdayStart, yesterdayEnd),
-          this.buildPaymentMethodBreakdown(selectedWhereClause),
-          this.prisma.sale.groupBy({
-            by: ['userId'],
-            where: selectedWhereClause,
-            _count: {
-              _all: true,
-            },
+      const [
+        xReport,
+        zReport,
+        paymentMethodsRange,
+        cashierRaw,
+        todayCashierRaw,
+      ] = await Promise.all([
+        buildSnapshot(todayStart, now),
+        buildSnapshot(yesterdayStart, yesterdayEnd),
+        this.buildPaymentMethodBreakdown(selectedWhereClause),
+        this.prisma.sale.groupBy({
+          by: ['userId'],
+          where: selectedWhereClause,
+          _count: {
+            _all: true,
+          },
+          _sum: {
+            total: true,
+          },
+          orderBy: {
             _sum: {
-              total: true,
+              total: 'desc',
             },
-            orderBy: {
-              _sum: {
-                total: 'desc',
-              },
-            },
-          }),
-          this.prisma.sale.groupBy({
-            by: ['userId'],
-            where: todayWhereClause,
-            _count: {
-              _all: true,
-            },
+          },
+        }),
+        this.prisma.sale.groupBy({
+          by: ['userId'],
+          where: todayWhereClause,
+          _count: {
+            _all: true,
+          },
+          _sum: {
+            total: true,
+          },
+          orderBy: {
             _sum: {
-              total: true,
+              total: 'desc',
             },
-            orderBy: {
-              _sum: {
-                total: 'desc',
-              },
-            },
-          }),
-        ]);
+          },
+        }),
+      ]);
 
       const paymentTotal = paymentMethodsRange.reduce(
         (sum, row) => sum + this.toNumber(row.amount),
@@ -341,7 +349,9 @@ export class AnalyticsService {
           transactionCount: this.toNumber(row.transactionCount),
           amount,
           sharePct:
-            paymentTotal > 0 ? Number(((amount / paymentTotal) * 100).toFixed(2)) : 0,
+            paymentTotal > 0
+              ? Number(((amount / paymentTotal) * 100).toFixed(2))
+              : 0,
         };
       });
 
@@ -361,7 +371,10 @@ export class AnalyticsService {
           })
         : [];
       const cashierMap = new Map(
-        cashierUsers.map((user) => [user.id, user.name || user.email || user.id]),
+        cashierUsers.map((user) => [
+          user.id,
+          user.name || user.email || user.id,
+        ]),
       );
 
       const byCashier = cashierRaw.map((row) => {
@@ -394,7 +407,10 @@ export class AnalyticsService {
         _count: { _all: true },
       });
 
-      const durationMs = Math.max(1, range.end.getTime() - range.start.getTime());
+      const durationMs = Math.max(
+        1,
+        range.end.getTime() - range.start.getTime(),
+      );
       const previousEnd = new Date(range.start);
       previousEnd.setMilliseconds(previousEnd.getMilliseconds() - 1);
       const previousStart = new Date(range.start.getTime() - durationMs);
@@ -417,7 +433,9 @@ export class AnalyticsService {
       const currentOrders = this.toNumber(currentAggregate._count?._all);
       const previousOrders = this.toNumber(previousAggregate._count?._all);
       const currentAvg =
-        currentOrders > 0 ? Number((currentSales / currentOrders).toFixed(2)) : 0;
+        currentOrders > 0
+          ? Number((currentSales / currentOrders).toFixed(2))
+          : 0;
       const previousAvg =
         previousOrders > 0
           ? Number((previousSales / previousOrders).toFixed(2))
@@ -441,11 +459,15 @@ export class AnalyticsService {
         todayByCashier,
         variance: {
           todayVsYesterday: {
-            salesDelta: Number((xReport.totalSales - zReport.totalSales).toFixed(2)),
+            salesDelta: Number(
+              (xReport.totalSales - zReport.totalSales).toFixed(2),
+            ),
             salesDeltaPct: pct(xReport.totalSales, zReport.totalSales),
             ordersDelta: xReport.totalOrders - zReport.totalOrders,
             ordersDeltaPct: pct(xReport.totalOrders, zReport.totalOrders),
-            avgTicketDelta: Number((xReport.avgTicket - zReport.avgTicket).toFixed(2)),
+            avgTicketDelta: Number(
+              (xReport.avgTicket - zReport.avgTicket).toFixed(2),
+            ),
             avgTicketDeltaPct: pct(xReport.avgTicket, zReport.avgTicket),
             comparedTo: {
               start: zReport.periodStart,
@@ -678,7 +700,11 @@ export class AnalyticsService {
     startDate.setDate(startDate.getDate() - 14);
 
     const rows = await this.prisma.$queryRaw<
-      Array<{ day: string; revenue: string | number | bigint; cost: string | number | bigint }>
+      Array<{
+        day: string;
+        revenue: string | number | bigint;
+        cost: string | number | bigint;
+      }>
     >(Prisma.sql`
       SELECT
         TO_CHAR(s."createdAt" AT TIME ZONE 'UTC', 'YYYY-MM-DD') as day,
@@ -752,7 +778,10 @@ export class AnalyticsService {
       Sat: 6,
     };
 
-    const buckets = new Map<string, { dow: number; hour: number; orders: number; revenue: number }>();
+    const buckets = new Map<
+      string,
+      { dow: number; hour: number; orders: number; revenue: number }
+    >();
 
     for (const sale of sales) {
       const dayShort = weekdayFormatter.format(sale.createdAt);
@@ -778,7 +807,7 @@ export class AnalyticsService {
     }
 
     return Array.from(buckets.values())
-      .sort((a, b) => (a.dow - b.dow) || (a.hour - b.hour))
+      .sort((a, b) => a.dow - b.dow || a.hour - b.hour)
       .map((row) => ({
         dow: row.dow,
         hour: row.hour,
@@ -990,6 +1019,385 @@ export class AnalyticsService {
     );
   }
 
+  private resolvePeriod(
+    from?: string,
+    to?: string,
+  ): { start: Date; end: Date } {
+    const end = to ? new Date(to) : new Date();
+    const start = from
+      ? new Date(from)
+      : new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+    return {
+      start: Number.isNaN(start.getTime())
+        ? new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000)
+        : start,
+      end: Number.isNaN(end.getTime()) ? new Date() : end,
+    };
+  }
+
+  async getInventoryMovement(
+    tenantId: string,
+    branchId?: string,
+    from?: string,
+    to?: string,
+  ) {
+    const { start, end } = this.resolvePeriod(from, to);
+
+    const movements = await this.prisma.inventoryMovement.findMany({
+      where: {
+        tenantId,
+        ...(branchId ? { branchId } : {}),
+        createdAt: { gte: start, lte: end },
+      },
+      select: {
+        type: true,
+        previousQuantity: true,
+        newQuantity: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const byDate = new Map<
+      string,
+      {
+        date: string;
+        receiptsQty: number;
+        issuesQty: number;
+        adjustmentsQty: number;
+        netMovementQty: number;
+      }
+    >();
+
+    for (const m of movements) {
+      const date = m.createdAt.toISOString().slice(0, 10);
+      const entry = byDate.get(date) ?? {
+        date,
+        receiptsQty: 0,
+        issuesQty: 0,
+        adjustmentsQty: 0,
+        netMovementQty: 0,
+      };
+      const netChange = m.newQuantity - m.previousQuantity;
+
+      if (m.type === 'in') entry.receiptsQty += Math.abs(netChange);
+      else if (m.type === 'out') entry.issuesQty += Math.abs(netChange);
+      else if (m.type === 'adjustment') entry.adjustmentsQty += netChange;
+      // 'transfer' movements net to zero tenant-wide but still affect this
+      // location's balance, so they're folded into netMovementQty only.
+
+      entry.netMovementQty += netChange;
+      byDate.set(date, entry);
+    }
+
+    return Array.from(byDate.values()).sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
+  }
+
+  async getInventoryValuation(tenantId: string, branchId?: string) {
+    const products = await this.prisma.product.findMany({
+      where: { tenantId, deletedAt: null, ...(branchId ? { branchId } : {}) },
+      select: {
+        id: true,
+        name: true,
+        price: true,
+        cost: true,
+        stock: true,
+        inventory: {
+          where: branchId ? { branchId } : undefined,
+          select: { quantity: true },
+        },
+      },
+    });
+
+    return products.map((product) => {
+      const stockQty =
+        product.inventory.length > 0
+          ? product.inventory.reduce((sum, inv) => sum + inv.quantity, 0)
+          : product.stock;
+      const costPrice = product.cost || 0;
+      const sellingPrice = product.price || 0;
+      const stockValue = stockQty * costPrice;
+      const potentialRevenue = stockQty * sellingPrice;
+      const marginPct =
+        sellingPrice > 0
+          ? ((sellingPrice - costPrice) / sellingPrice) * 100
+          : 0;
+
+      return {
+        productId: product.id,
+        productName: product.name,
+        stockQty,
+        costPrice,
+        sellingPrice,
+        stockValue,
+        potentialRevenue,
+        marginPct: Math.round(marginPct * 100) / 100,
+      };
+    });
+  }
+
+  async getInventoryAging(tenantId: string, branchId?: string) {
+    const products = await this.prisma.product.findMany({
+      where: { tenantId, deletedAt: null, ...(branchId ? { branchId } : {}) },
+      select: {
+        id: true,
+        name: true,
+        cost: true,
+        stock: true,
+        updatedAt: true,
+        inventory: {
+          where: branchId ? { branchId } : undefined,
+          select: { quantity: true, updatedAt: true },
+        },
+      },
+    });
+
+    const now = new Date();
+    const results: Array<{
+      productId: string;
+      productName: string;
+      stockQty: number;
+      lastReceivedAt: string;
+      daysInStock: number;
+      ageBucket: '0-30' | '31-60' | '61-90' | '90+';
+      unitCost: number;
+      stockValue: number;
+    }> = [];
+
+    for (const product of products) {
+      const stockQty =
+        product.inventory.length > 0
+          ? product.inventory.reduce((sum, inv) => sum + inv.quantity, 0)
+          : product.stock;
+
+      if (stockQty <= 0) continue;
+
+      const lastInMovement = await this.prisma.inventoryMovement.findFirst({
+        where: {
+          productId: product.id,
+          type: 'in',
+          ...(branchId ? { branchId } : {}),
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      });
+
+      const lastReceivedAt =
+        lastInMovement?.createdAt ||
+        product.inventory[0]?.updatedAt ||
+        product.updatedAt;
+
+      const daysInStock = Math.max(
+        0,
+        Math.floor(
+          (now.getTime() - new Date(lastReceivedAt).getTime()) /
+            (1000 * 60 * 60 * 24),
+        ),
+      );
+
+      const ageBucket =
+        daysInStock <= 30
+          ? '0-30'
+          : daysInStock <= 60
+            ? '31-60'
+            : daysInStock <= 90
+              ? '61-90'
+              : '90+';
+
+      const unitCost = product.cost || 0;
+
+      results.push({
+        productId: product.id,
+        productName: product.name,
+        stockQty,
+        lastReceivedAt: new Date(lastReceivedAt).toISOString(),
+        daysInStock,
+        ageBucket,
+        unitCost,
+        stockValue: stockQty * unitCost,
+      });
+    }
+
+    return results.sort((a, b) => b.daysInStock - a.daysInStock);
+  }
+
+  async getInventoryTurnover(
+    tenantId: string,
+    branchId?: string,
+    from?: string,
+    to?: string,
+  ) {
+    const { start, end } = this.resolvePeriod(from, to);
+
+    const products = await this.prisma.product.findMany({
+      where: { tenantId, deletedAt: null, ...(branchId ? { branchId } : {}) },
+      select: {
+        id: true,
+        name: true,
+        stock: true,
+        inventory: {
+          where: branchId ? { branchId } : undefined,
+          select: { quantity: true },
+        },
+      },
+    });
+
+    const results: Array<{
+      productId: string;
+      productName: string;
+      soldUnits: number;
+      averageStock: number;
+      turnoverRatio: number;
+      periodStart: string;
+      periodEnd: string;
+    }> = [];
+    for (const product of products) {
+      const salesAgg = await this.prisma.saleItem.aggregate({
+        where: {
+          productId: product.id,
+          sale: {
+            tenantId,
+            createdAt: { gte: start, lte: end },
+            ...(branchId ? { branchId } : {}),
+          },
+        },
+        _sum: { quantity: true },
+      });
+
+      const soldUnits = salesAgg._sum.quantity || 0;
+      // No historical stock snapshots are recorded, so current on-hand
+      // quantity is used as the average-stock denominator.
+      const averageStock =
+        product.inventory.length > 0
+          ? product.inventory.reduce((sum, inv) => sum + inv.quantity, 0)
+          : product.stock;
+
+      const turnoverRatio = averageStock > 0 ? soldUnits / averageStock : 0;
+
+      results.push({
+        productId: product.id,
+        productName: product.name,
+        soldUnits,
+        averageStock,
+        turnoverRatio: Math.round(turnoverRatio * 100) / 100,
+        periodStart: start.toISOString(),
+        periodEnd: end.toISOString(),
+      });
+    }
+
+    return results.sort((a, b) => b.turnoverRatio - a.turnoverRatio);
+  }
+
+  private extractProductCategory(customFields: unknown): string {
+    if (
+      !customFields ||
+      typeof customFields !== 'object' ||
+      Array.isArray(customFields)
+    ) {
+      return 'Uncategorized';
+    }
+    const raw = (customFields as Record<string, unknown>).category;
+    const name = typeof raw === 'string' ? raw.trim() : '';
+    return name || 'Uncategorized';
+  }
+
+  async getProductCategoryAnalysis(
+    tenantId: string,
+    branchId?: string,
+    from?: string,
+    to?: string,
+  ) {
+    const { start, end } = this.resolvePeriod(from, to);
+
+    const products = await this.prisma.product.findMany({
+      where: { tenantId, deletedAt: null, ...(branchId ? { branchId } : {}) },
+      select: {
+        id: true,
+        cost: true,
+        stock: true,
+        customFields: true,
+        inventory: {
+          where: branchId ? { branchId } : undefined,
+          select: { quantity: true },
+        },
+      },
+    });
+
+    const categories = new Map<
+      string,
+      { revenue: number; unitsSold: number; cogs: number; stockValue: number }
+    >();
+
+    for (const product of products) {
+      const categoryName = this.extractProductCategory(product.customFields);
+      const entry = categories.get(categoryName) ?? {
+        revenue: 0,
+        unitsSold: 0,
+        cogs: 0,
+        stockValue: 0,
+      };
+
+      const salesAgg = await this.prisma.saleItem.aggregate({
+        where: {
+          productId: product.id,
+          sale: {
+            tenantId,
+            createdAt: { gte: start, lte: end },
+            ...(branchId ? { branchId } : {}),
+          },
+        },
+        _sum: { quantity: true },
+      });
+      // Revenue is computed from actual sale line prices, not current list
+      // price, so historical discounts/price changes are reflected.
+      const saleItems = await this.prisma.saleItem.findMany({
+        where: {
+          productId: product.id,
+          sale: {
+            tenantId,
+            createdAt: { gte: start, lte: end },
+            ...(branchId ? { branchId } : {}),
+          },
+        },
+        select: { price: true, quantity: true },
+      });
+
+      const revenue = saleItems.reduce(
+        (sum, item) => sum + item.price * item.quantity,
+        0,
+      );
+      const unitsSold = salesAgg._sum.quantity || 0;
+      const cogs = unitsSold * (product.cost || 0);
+      const stockQty =
+        product.inventory.length > 0
+          ? product.inventory.reduce((sum, inv) => sum + inv.quantity, 0)
+          : product.stock;
+
+      entry.revenue += revenue;
+      entry.unitsSold += unitsSold;
+      entry.cogs += cogs;
+      entry.stockValue += stockQty * (product.cost || 0);
+      categories.set(categoryName, entry);
+    }
+
+    return Array.from(categories.entries())
+      .map(([categoryName, data]) => ({
+        categoryId: categoryName.toLowerCase().replace(/\s+/g, '-'),
+        categoryName,
+        revenue: data.revenue,
+        unitsSold: data.unitsSold,
+        marginPct:
+          data.revenue > 0
+            ? Math.round(((data.revenue - data.cogs) / data.revenue) * 10000) /
+              100
+            : 0,
+        stockValue: data.stockValue,
+      }))
+      .sort((a, b) => b.revenue - a.revenue);
+  }
+
   private async getBranchSalesByTimePeriod(
     tenantId: string,
     period: 'day' | 'week' | 'month' | 'year',
@@ -1190,7 +1598,10 @@ export class AnalyticsService {
     `);
 
     const inventoryByProduct = new Map<string, number>(
-      inventoryRows.map((row) => [row.productId, Number(row.totalQuantity) || 0]),
+      inventoryRows.map((row) => [
+        row.productId,
+        Number(row.totalQuantity) || 0,
+      ]),
     );
 
     const lowStockThreshold = 10; // Items below this are considered low stock
@@ -1573,7 +1984,8 @@ export class AnalyticsService {
         LIMIT 5
       `;
 
-      const paymentMethods = await this.buildPaymentMethodBreakdown(whereClause);
+      const paymentMethods =
+        await this.buildPaymentMethodBreakdown(whereClause);
 
       // Get sales trend (daily)
       const salesTrendData = await this.prisma.$queryRaw`

--- a/src/backup/backup.controller.ts
+++ b/src/backup/backup.controller.ts
@@ -4,16 +4,25 @@ import {
   Post,
   Body,
   Param,
+  Res,
   HttpException,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { createReadStream } from 'fs';
+import { basename } from 'path';
 import { BackupService } from './backup.service';
 import { BackupStatusDto, BackupListDto } from './dto/backup-status.dto';
 import { CreateBackupDto } from './dto/create-backup.dto';
+import { SuperadminGuard } from '../admin/superadmin.guard';
+import { TrialGuard } from '../auth/trial.guard';
 
 @ApiTags('Backup')
 @Controller('backup')
+@UseGuards(AuthGuard('jwt'), SuperadminGuard, TrialGuard)
 export class BackupController {
   constructor(private readonly backupService: BackupService) {}
 
@@ -76,10 +85,10 @@ export class BackupController {
   }
 
   @Post('restore/:filename')
-  @ApiOperation({ summary: 'Restore from backup (not yet implemented)' })
+  @ApiOperation({ summary: 'Restore database from a backup file' })
   @ApiResponse({
-    status: 501,
-    description: 'Restore functionality not yet implemented',
+    status: 201,
+    description: 'Backup restored successfully',
   })
   async restoreBackup(@Param('filename') filename: string) {
     try {
@@ -100,26 +109,32 @@ export class BackupController {
   @ApiOperation({ summary: 'Download backup file' })
   @ApiResponse({
     status: 200,
-    description: 'Backup file download initiated',
+    description: 'Backup file stream',
   })
   @ApiResponse({
     status: 404,
     description: 'Backup file not found',
   })
-  async downloadBackup(@Param('filename') filename: string) {
+  async downloadBackup(
+    @Param('filename') filename: string,
+    @Res() res: Response,
+  ): Promise<void> {
     try {
       const filePath = await this.backupService.getBackupPath(filename);
-      // In a real implementation, you would return a stream or use a file serving mechanism
-      // For now, just return the path info
-      return {
-        success: true,
-        message: 'Backup file found',
-        data: {
-          filename,
-          path: filePath,
-          note: 'Direct download not implemented yet. File path provided for manual access.',
-        },
-      };
+      const safeName = basename(filePath);
+      res.set({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': `attachment; filename="${safeName}"`,
+      });
+      const stream = createReadStream(filePath);
+      stream.on('error', () => {
+        if (!res.headersSent) {
+          res.status(HttpStatus.INTERNAL_SERVER_ERROR).end();
+        } else {
+          res.end();
+        }
+      });
+      stream.pipe(res);
     } catch (error) {
       throw new HttpException(
         this.getErrorMessage(error),

--- a/src/backup/backup.service.ts
+++ b/src/backup/backup.service.ts
@@ -84,14 +84,7 @@ export class BackupService {
       }
 
       // Parse database URL for pg_dump parameters
-      const dbUrlMatch = dbUrl.match(
-        /postgresql:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)/,
-      );
-      if (!dbUrlMatch) {
-        throw new Error('Invalid DATABASE_URL format');
-      }
-
-      const [, user, password, host, port, database] = dbUrlMatch;
+      const { user, password, host, port, database } = this.parseDbUrl(dbUrl);
 
       // Create pg_dump command with gzip compression
       const pgDumpCommand = `pg_dump --host=${host} --port=${port} --username=${user} --dbname=${database} --no-password --format=custom --compress=9 --file="${backupPath}"`;
@@ -260,15 +253,54 @@ export class BackupService {
     }
   }
 
-  restoreBackup(filename: string): Promise<void> {
-    // This would implement restore functionality
-    // For now, just log that it's not implemented
-    this.logger.warn(
-      `Restore functionality not yet implemented for ${filename}`,
+  private parseDbUrl(dbUrl: string): {
+    user: string;
+    password: string;
+    host: string;
+    port: string;
+    database: string;
+  } {
+    const dbUrlMatch = dbUrl.match(
+      /postgresql:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)/,
     );
-    return Promise.reject(
-      new Error('Restore functionality not yet implemented'),
-    );
+    if (!dbUrlMatch) {
+      throw new Error('Invalid DATABASE_URL format');
+    }
+    const [, user, password, host, port, database] = dbUrlMatch;
+    return { user, password, host, port, database };
+  }
+
+  async restoreBackup(filename: string): Promise<void> {
+    // Validate the filename resolves to a real file within the backup directory
+    const backupPath = await this.getBackupPath(filename);
+
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) {
+      throw new Error('DATABASE_URL environment variable not set');
+    }
+    const { user, password, host, port, database } = this.parseDbUrl(dbUrl);
+
+    // --clean --if-exists drops existing objects before recreating them so the
+    // restore is idempotent against the current schema state.
+    const pgRestoreCommand = `pg_restore --host=${host} --port=${port} --username=${user} --dbname=${database} --no-password --clean --if-exists "${backupPath}"`;
+    const env = { ...process.env, PGPASSWORD: password };
+
+    this.logger.warn(`Restoring database ${database} from ${filename}`);
+
+    try {
+      const { stderr } = await execAsync(pgRestoreCommand, { env });
+      // pg_restore writes non-fatal warnings to stderr even on success, so log
+      // them but do not treat their presence as failure.
+      if (stderr) {
+        this.logger.warn(`pg_restore warnings for ${filename}: ${stderr}`);
+      }
+      this.logger.log(`Restore completed successfully from ${filename}`);
+    } catch (error) {
+      this.logger.error(
+        `Restore failed for ${filename}: ${this.getErrorMessage(error)}`,
+      );
+      throw new Error(`Restore failed: ${this.getErrorMessage(error)}`);
+    }
   }
 
   async getBackupPath(filename: string): Promise<string> {

--- a/src/billing/subscription.guard.ts
+++ b/src/billing/subscription.guard.ts
@@ -7,11 +7,6 @@ import {
 import { PrismaService } from '../prisma.service';
 import { AuthenticatedRequest } from '../auth/request.types';
 
-type ActiveSubscription = {
-  status: string;
-  currentPeriodEnd: Date;
-};
-
 @Injectable()
 export class SubscriptionGuard implements CanActivate {
   constructor(private readonly prisma: PrismaService) {}
@@ -25,7 +20,7 @@ export class SubscriptionGuard implements CanActivate {
     }
 
     // Fetch active subscription for tenant
-    const subscription = (await this.prisma.subscription.findFirst({
+    const subscription = await this.prisma.subscription.findFirst({
       where: {
         tenantId,
         status: {
@@ -36,7 +31,7 @@ export class SubscriptionGuard implements CanActivate {
         status: true,
         currentPeriodEnd: true,
       },
-    })) as ActiveSubscription | null;
+    });
 
     if (!subscription) {
       throw new ForbiddenException('No active or trial subscription found');
@@ -50,13 +45,15 @@ export class SubscriptionGuard implements CanActivate {
       throw new ForbiddenException('Subscription payment is overdue');
     }
 
-    // Example enforcement: check maxUsers limit
-    // This is a placeholder, actual enforcement logic depends on the resource being accessed
-    // For example, if accessing user management, check current user count vs maxUsers
-
-    // You can extend this guard to check other limits like maxProducts, maxSalesPerMonth, etc.
-
-    // If all checks pass
+    // Resource-count limits (maxUsers, maxBranches, maxProducts,
+    // maxSalesPerMonth) are enforced at the point of creation in each
+    // resource's own service (see user.service.ts, branch.service.ts,
+    // product.service.ts, sales.service.ts via SubscriptionService.canAddX),
+    // not here — this guard only asserts that a subscription is active.
+    // Route-wide suspension/expiry is also already enforced globally by
+    // JwtStrategy for every authenticated, non-billing route. Apply this
+    // guard in addition to that when a specific route should be blocked
+    // outright rather than allowed through with a restricted-mode response.
     return true;
   }
 }

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
+import { jobQueue, QUEUE_NAMES } from '../queue';
 
 @Injectable()
 export class EmailService {
@@ -7,6 +8,14 @@ export class EmailService {
   private transporter: nodemailer.Transporter<nodemailer.SentMessageInfo>;
 
   constructor() {
+    // Actual delivery happens off the request path via the in-process job
+    // queue, which also retries transient SMTP failures instead of failing
+    // the caller's request outright.
+    jobQueue.registerHandler<nodemailer.SendMailOptions>(
+      QUEUE_NAMES.EMAIL,
+      (mailOptions) => this.sendMail(mailOptions),
+    );
+
     // For development, use Ethereal test service by default
     // Only use Gmail if explicitly configured with valid credentials
     const useGmail = process.env.USE_GMAIL === 'true';
@@ -81,7 +90,7 @@ export class EmailService {
     return sendMailFn(mailOptions).then(() => undefined);
   }
 
-  async sendResetPasswordEmail(to: string, token: string): Promise<void> {
+  sendResetPasswordEmail(to: string, token: string): void {
     const resetUrl = `http://localhost:5000/reset-password?token=${token}`;
     const html = `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
@@ -104,20 +113,15 @@ export class EmailService {
       html,
     };
 
-    try {
-      await this.sendMail(mailOptions);
-      this.logger.log(`Reset password email sent to ${to}`);
-    } catch (error) {
-      this.logger.error(`Failed to send reset email to ${to}:`, error);
-      throw error;
-    }
+    jobQueue.enqueue(QUEUE_NAMES.EMAIL, mailOptions);
+    this.logger.log(`Reset password email queued for ${to}`);
   }
 
-  async sendPaymentConfirmationEmail(
+  sendPaymentConfirmationEmail(
     to: string,
     subject: string,
     html: string,
-  ): Promise<void> {
+  ): void {
     const mailOptions: nodemailer.SendMailOptions = {
       from:
         process.env.FROM_EMAIL || '"SaaS Platform" <noreply@saasplatform.com>',
@@ -126,15 +130,7 @@ export class EmailService {
       html,
     };
 
-    try {
-      await this.sendMail(mailOptions);
-      this.logger.log(`Payment confirmation email sent to ${to}`);
-    } catch (error) {
-      this.logger.error(
-        `Failed to send payment confirmation email to ${to}:`,
-        error,
-      );
-      throw error;
-    }
+    jobQueue.enqueue(QUEUE_NAMES.EMAIL, mailOptions);
+    this.logger.log(`Payment confirmation email queued for ${to}`);
   }
 }

--- a/src/mpesa/mpesa.controller.ts
+++ b/src/mpesa/mpesa.controller.ts
@@ -89,7 +89,13 @@ export class MpesaController {
     message?: string | null,
     mpesaReceipt?: string | null,
     createdAt?: Date | string,
-  ): 'pending' | 'success' | 'failed' | 'cancelled' | 'timeout' | 'stock_unavailable' {
+  ):
+    | 'pending'
+    | 'success'
+    | 'failed'
+    | 'cancelled'
+    | 'timeout'
+    | 'stock_unavailable' {
     const normalizedStatus = String(status || '').toLowerCase();
     const normalizedMessage = String(message || '').toLowerCase();
     const hasReceipt = Boolean(String(mpesaReceipt || '').trim());
@@ -176,9 +182,11 @@ export class MpesaController {
   }
 
   @Post('initiate')
+  @UseGuards(AuthGuard('jwt'))
   async initiatePayment(
     @Body() body: InitiatePaymentBody,
     @Res() res: Response,
+    @Req() req: AuthenticatedRequest,
   ) {
     try {
       const { phoneNumber, amount, reference, transactionDesc, tenantId } =
@@ -189,13 +197,20 @@ export class MpesaController {
         JSON.stringify(body, null, 2),
       );
 
-      // Get tenantId from authenticated user (assuming req.user has tenantId)
-      // For now, require tenantId in body; in production, extract from JWT
       if (!tenantId) {
         console.log('Tenant ID validation failed');
         return res
           .status(HttpStatus.BAD_REQUEST)
           .json({ error: 'Tenant ID required' });
+      }
+
+      const user = req?.user;
+      const canInitiate =
+        !!user && (user.tenantId === tenantId || user.isSuperadmin === true);
+      if (!canInitiate) {
+        return res.status(HttpStatus.FORBIDDEN).json({
+          error: 'You can only initiate payments for your own tenant.',
+        });
       }
 
       // Validate amount
@@ -342,7 +357,11 @@ export class MpesaController {
   }
 
   @Post('callback')
-  async mpesaWebhook(@Body() body: MpesaCallbackBody, @Res() res: Response) {
+  async mpesaWebhook(
+    @Body() body: MpesaCallbackBody,
+    @Query('token') token: string | undefined,
+    @Res() res: Response,
+  ) {
     console.log('=== M-PESA CALLBACK RECEIVED ===');
     console.log('Callback body:', JSON.stringify(body, null, 2));
 
@@ -363,6 +382,34 @@ export class MpesaController {
         );
 
         const checkoutRequestId = CheckoutRequestID;
+
+        // Safaricom doesn't sign callbacks, so we verify against the
+        // per-tenant HMAC token we embedded in the CallBackURL we registered
+        // for this checkout request, and confirm the checkout ID corresponds
+        // to a transaction we actually initiated.
+        const pendingTx = checkoutRequestId
+          ? await this.mpesaService.prisma.mpesaTransaction.findFirst({
+              where: { checkoutRequestID: checkoutRequestId },
+            })
+          : null;
+
+        if (!pendingTx || !pendingTx.tenantId) {
+          console.warn(
+            `M-Pesa callback rejected: unknown CheckoutRequestID ${checkoutRequestId ?? ''}`,
+          );
+          return res
+            .status(HttpStatus.NOT_FOUND)
+            .json({ error: 'Unknown transaction' });
+        }
+
+        if (!this.mpesaService.verifyCallbackToken(pendingTx.tenantId, token)) {
+          console.warn(
+            `M-Pesa callback rejected: invalid token for CheckoutRequestID ${checkoutRequestId ?? ''}`,
+          );
+          return res
+            .status(HttpStatus.FORBIDDEN)
+            .json({ error: 'Invalid callback token' });
+        }
         const status = ResultCode === 0 ? 'success' : 'failed';
         let mpesaReceipt = undefined;
         let transactionId = undefined;
@@ -681,12 +728,17 @@ export class MpesaController {
   }
 
   @Get('status/:checkoutRequestId')
-  async getStatus(@Param('checkoutRequestId') checkoutRequestId: string) {
+  @UseGuards(AuthGuard('jwt'))
+  async getStatus(
+    @Param('checkoutRequestId') checkoutRequestId: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
     console.log('Getting status for checkoutRequestId:', checkoutRequestId);
-    let transaction =
-      await this.mpesaService.prisma.mpesaTransaction.findFirst({
+    let transaction = await this.mpesaService.prisma.mpesaTransaction.findFirst(
+      {
         where: { checkoutRequestID: checkoutRequestId },
-      });
+      },
+    );
 
     if (!transaction) {
       console.log(
@@ -694,6 +746,16 @@ export class MpesaController {
         checkoutRequestId,
       );
       return { success: false, error: 'Transaction not found' };
+    }
+
+    const user = req?.user;
+    const canView =
+      !!user &&
+      (user.tenantId === transaction.tenantId || user.isSuperadmin === true);
+    if (!canView) {
+      throw new ForbiddenException(
+        'You can only view M-Pesa transactions for your own tenant.',
+      );
     }
 
     if (transaction.status === 'pending' && transaction.tenantId) {
@@ -732,9 +794,11 @@ export class MpesaController {
           });
         }
 
-        transaction = await this.mpesaService.prisma.mpesaTransaction.findFirst({
-          where: { checkoutRequestID: checkoutRequestId },
-        });
+        transaction = await this.mpesaService.prisma.mpesaTransaction.findFirst(
+          {
+            where: { checkoutRequestID: checkoutRequestId },
+          },
+        );
       } catch (error) {
         console.warn(
           'STK status reconciliation failed for checkoutRequestId:',
@@ -766,15 +830,34 @@ export class MpesaController {
   }
 
   @Get('transaction/:checkoutRequestId')
+  @UseGuards(AuthGuard('jwt'))
   async getByCheckoutId(
     @Param('checkoutRequestId') checkoutRequestId: string,
     @Res() res: Response,
+    @Req() req: AuthenticatedRequest,
   ) {
     try {
       const transaction =
         await this.mpesaService.prisma.mpesaTransaction.findFirst({
           where: { checkoutRequestID: checkoutRequestId },
         });
+
+      if (!transaction) {
+        return res
+          .status(HttpStatus.NOT_FOUND)
+          .json({ error: 'Transaction not found' });
+      }
+
+      const user = req?.user;
+      const canView =
+        !!user &&
+        (user.tenantId === transaction.tenantId || user.isSuperadmin === true);
+      if (!canView) {
+        return res.status(HttpStatus.FORBIDDEN).json({
+          error: 'You can only view M-Pesa transactions for your own tenant.',
+        });
+      }
+
       return res.json(transaction);
     } catch {
       return res
@@ -866,8 +949,8 @@ export class MpesaController {
         ? Math.max(1, Math.min(1000, Math.floor(parsedLimit)))
         : 500;
 
-      const transactions = await this.mpesaService.prisma.mpesaTransaction.findMany(
-        {
+      const transactions =
+        await this.mpesaService.prisma.mpesaTransaction.findMany({
           where: whereClause,
           orderBy: { createdAt: 'desc' },
           include: {
@@ -896,8 +979,7 @@ export class MpesaController {
             },
           },
           take,
-        },
-      );
+        });
 
       const summary = transactions.reduce(
         (acc, tx) => {
@@ -942,7 +1024,7 @@ export class MpesaController {
         new Map(
           transactions
             .filter((tx) => tx.sale?.User)
-            .map((tx) => [tx.sale!.User!.id, tx.sale!.User!]),
+            .map((tx) => [tx.sale!.User.id, tx.sale!.User]),
         ).values(),
       ).sort((a, b) => a.name.localeCompare(b.name));
 
@@ -982,10 +1064,10 @@ export class MpesaController {
                   total: transaction.sale.total,
                   customerName: transaction.sale.customerName ?? undefined,
                   customerPhone: transaction.sale.customerPhone ?? undefined,
-                branchId: transaction.sale.branchId ?? undefined,
-                cashierId: transaction.sale.userId ?? undefined,
-                branchName: transaction.sale.Branch?.name ?? undefined,
-                cashierName: transaction.sale.User?.name ?? undefined,
+                  branchId: transaction.sale.branchId ?? undefined,
+                  cashierId: transaction.sale.userId ?? undefined,
+                  branchName: transaction.sale.Branch?.name ?? undefined,
+                  cashierName: transaction.sale.User?.name ?? undefined,
                 }
               : undefined,
           };

--- a/src/mpesa/mpesa.service.ts
+++ b/src/mpesa/mpesa.service.ts
@@ -6,6 +6,42 @@ import * as crypto from 'crypto';
 export class MpesaService {
   constructor(public readonly prisma: PrismaService) {}
 
+  /**
+   * Safaricom does not sign STK callbacks, so we embed a per-tenant HMAC
+   * token in the CallBackURL we register with them and verify it on the way
+   * back in. This stops arbitrary POSTs to /mpesa/callback from being able
+   * to fabricate a successful payment for a tenant they can't derive the
+   * token for.
+   */
+  computeCallbackToken(tenantId: string): string {
+    const secret = process.env.MPESA_CALLBACK_SECRET || process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error(
+        'MPESA_CALLBACK_SECRET (or JWT_SECRET) must be set to secure M-Pesa callbacks.',
+      );
+    }
+    return crypto
+      .createHmac('sha256', secret)
+      .update(tenantId)
+      .digest('hex')
+      .slice(0, 32);
+  }
+
+  verifyCallbackToken(tenantId: string, token: string | undefined): boolean {
+    if (!token) return false;
+    const expected = this.computeCallbackToken(tenantId);
+    const expectedBuf = Buffer.from(expected);
+    const tokenBuf = Buffer.from(token);
+    if (expectedBuf.length !== tokenBuf.length) return false;
+    return crypto.timingSafeEqual(expectedBuf, tokenBuf);
+  }
+
+  appendCallbackToken(callbackUrl: string, tenantId: string): string {
+    const token = this.computeCallbackToken(tenantId);
+    const separator = callbackUrl.includes('?') ? '&' : '?';
+    return `${callbackUrl}${separator}token=${token}`;
+  }
+
   async getTenantMpesaConfig(tenantId: string, requireActive = true) {
     if (!tenantId) {
       throw new BadRequestException('Tenant ID is required.');
@@ -179,8 +215,10 @@ export class MpesaService {
       PartyA: phoneNumber,
       PartyB: config.shortCode,
       PhoneNumber: phoneNumber,
-      CallBackURL:
+      CallBackURL: this.appendCallbackToken(
         config.callbackUrl || `${process.env.BASE_URL}/mpesa/callback`,
+        tenantId,
+      ),
       AccountReference: reference || 'Saas Platform',
       TransactionDesc: transactionDesc || 'Payment for Saas Platform',
     };

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { Prisma } from '@prisma/client';
@@ -194,7 +195,9 @@ export class ProductService {
       }
     }
 
-    const stale = existing.filter((entry) => !desiredCodes.includes(entry.code));
+    const stale = existing.filter(
+      (entry) => !desiredCodes.includes(entry.code),
+    );
     if (stale.length > 0) {
       await tx.productVariationBarcode.updateMany({
         where: { id: { in: stale.map((entry) => entry.id) } },
@@ -597,6 +600,31 @@ export class ProductService {
   ) {
     if (!data.tenantId || !data.branchId) {
       throw new BadRequestException('tenantId and branchId are required');
+    }
+
+    // Skip plan limits check when no subscription exists yet (e.g. during
+    // initial tenant setup), mirroring branch/user/sale creation enforcement.
+    try {
+      const canAddProduct = await this.subscriptionService.canAddProduct(
+        data.tenantId,
+      );
+      if (!canAddProduct) {
+        const subscription =
+          await this.subscriptionService.getCurrentSubscription(data.tenantId);
+        const maxProducts = subscription.plan?.maxProducts || 0;
+        throw new ForbiddenException(
+          `Product limit exceeded. Your plan allows up to ${maxProducts} products. Please upgrade your plan to add more products.`,
+        );
+      }
+    } catch (error) {
+      if (
+        error instanceof NotFoundException &&
+        /No active( or trial)? subscription found/i.test(error.message)
+      ) {
+        // Allow product creation for tenants without a subscription yet
+      } else {
+        throw error;
+      }
     }
 
     const productData: Record<string, unknown> = {
@@ -1241,7 +1269,7 @@ export class ProductService {
             price: data.price ?? 0,
             cost: data.cost ?? 0,
             stock: data.stock,
-            attributes: (data.attributes ?? {}) as Prisma.InputJsonValue,
+            attributes: data.attributes ?? {},
             tenantId: data.tenantId,
             branchId: data.branchId ?? null,
             barcode: normalizedPrimaryBarcode || null,

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,22 +1,117 @@
-// Placeholder for future background job processing
-// BullMQ queues will be implemented when Redis 5.0+ is available
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('JobQueue');
 
 export const QUEUE_NAMES = {
   EMAIL: 'emailQueue',
   REPORT: 'reportQueue',
 } as const;
 
-// Temporary synchronous processing functions
-export const processEmail = (_emailData: unknown) => {
-  void _emailData;
-  // This will be replaced with actual queue processing when Redis is upgraded
-  console.log('Email processing placeholder - synchronous processing');
-  return { success: true, message: 'Email queued for processing' };
-};
+export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
 
-export const processReport = (_reportData: unknown) => {
-  void _reportData;
-  // This will be replaced with actual queue processing when Redis is upgraded
-  console.log('Report processing placeholder - synchronous processing');
-  return { success: true, message: 'Report queued for processing' };
-};
+export type JobHandler<T> = (data: T) => Promise<void>;
+
+interface Job<T> {
+  id: string;
+  queue: QueueName;
+  data: T;
+  attempt: number;
+}
+
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 2000;
+const CONCURRENCY = 3;
+
+/**
+ * Minimal in-process job queue: concurrency-limited, retries failed jobs
+ * with backoff, and actually logs outcomes instead of a console.log that
+ * unconditionally reported success. No Redis dependency, since none is
+ * provisioned in this environment — jobs are lost on process restart, so
+ * this suits best-effort work (email delivery) rather than anything that
+ * must survive a crash.
+ */
+class InProcessQueue {
+  private handlers = new Map<QueueName, JobHandler<unknown>>();
+  private pending: Job<unknown>[] = [];
+  private active = 0;
+  private nextId = 1;
+
+  registerHandler<T>(queue: QueueName, handler: JobHandler<T>): void {
+    this.handlers.set(queue, handler);
+  }
+
+  enqueue<T>(queue: QueueName, data: T): string {
+    const job: Job<T> = {
+      id: `job-${this.nextId++}`,
+      queue,
+      data,
+      attempt: 0,
+    };
+    this.pending.push(job);
+    void this.drain();
+    return job.id;
+  }
+
+  private drain(): void {
+    while (this.active < CONCURRENCY && this.pending.length > 0) {
+      const job = this.pending.shift();
+      if (!job) break;
+      this.active++;
+      void this.process(job).finally(() => {
+        this.active--;
+        this.drain();
+      });
+    }
+  }
+
+  private async process(job: Job<unknown>): Promise<void> {
+    const handler = this.handlers.get(job.queue);
+    if (!handler) {
+      logger.warn(
+        `No handler registered for queue "${job.queue}", dropping job ${job.id}`,
+      );
+      return;
+    }
+    job.attempt++;
+    try {
+      await handler(job.data);
+      logger.log(`Job ${job.id} on ${job.queue} completed`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(
+        `Job ${job.id} on ${job.queue} failed (attempt ${job.attempt}/${MAX_ATTEMPTS}): ${message}`,
+      );
+      if (job.attempt < MAX_ATTEMPTS) {
+        const delay = RETRY_BASE_DELAY_MS * job.attempt;
+        setTimeout(() => {
+          this.pending.push(job);
+          this.drain();
+        }, delay);
+      } else {
+        logger.error(
+          `Job ${job.id} on ${job.queue} exhausted ${MAX_ATTEMPTS} attempts, giving up`,
+        );
+      }
+    }
+  }
+}
+
+export const jobQueue = new InProcessQueue();
+
+export function processEmail<T>(emailData: T): {
+  success: boolean;
+  message: string;
+  jobId: string;
+} {
+  const jobId = jobQueue.enqueue(QUEUE_NAMES.EMAIL, emailData);
+  return { success: true, message: 'Email queued for processing', jobId };
+}
+
+export function processReport<T>(reportData: T): {
+  success: boolean;
+  message: string;
+  jobId: string;
+} {
+  const jobId = jobQueue.enqueue(QUEUE_NAMES.REPORT, reportData);
+  return { success: true, message: 'Report queued for processing', jobId };
+}

--- a/src/tenant/logo.service.ts
+++ b/src/tenant/logo.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { NotFoundException } from '@nestjs/common';
 import { Express } from 'express';
+import { promises as fs, existsSync } from 'fs';
+import * as path from 'path';
 
 export interface LogoValidation {
   isValid: boolean;
@@ -258,8 +260,7 @@ export class LogoService {
   }
 
   async updateLogo(tenantId: string, file: MulterFile) {
-    // Upload the file to storage (e.g., S3, local storage, etc.)
-    const logoUrl = this.uploadFile(file);
+    const logoUrl = await this.uploadFile(file);
 
     // Update the tenant with the new logo URL
     const updatedTenant = await this.prisma.tenant.update({
@@ -274,8 +275,7 @@ export class LogoService {
   }
 
   async updateEtimsQrCode(tenantId: string, file: MulterFile) {
-    // Upload the file to storage
-    const etimsQrUrl = this.uploadFile(file);
+    const etimsQrUrl = await this.uploadFile(file);
 
     // Update the tenant with the new ETIMS QR code URL
     const updatedTenant = await this.prisma.tenant.update({
@@ -289,15 +289,35 @@ export class LogoService {
     };
   }
 
-  private uploadFile(file: MulterFile): string {
-    // Implement your file upload logic here
-    // This is a placeholder - replace with your actual file storage implementation
-    const fileName = `${Date.now()}-${file.originalname}`;
-    // Example: Upload to S3 or save to disk
-    // const result = await this.storageService.upload(file.buffer, fileName, file.mimetype);
-    // return result.url;
+  /**
+   * Persists an uploaded logo to the same uploads/logos directory served
+   * statically at /uploads/logos by main.ts, and returns its public URL.
+   * Handles both memory storage (file.buffer) and disk storage (file.path,
+   * already written by multer) depending on how the calling controller's
+   * FileInterceptor is configured.
+   */
+  private async uploadFile(file: MulterFile): Promise<string> {
+    const uploadsRoot =
+      process.env.UPLOADS_DIR || path.join(process.cwd(), 'uploads');
+    const logosDir = path.join(uploadsRoot, 'logos');
+    const ext = path.extname(file.originalname) || '';
+    const fileName = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
+    const destPath = path.join(logosDir, fileName);
 
-    // For now, return a placeholder URL
-    return `/uploads/${fileName}`;
+    if (!existsSync(logosDir)) {
+      await fs.mkdir(logosDir, { recursive: true });
+    }
+
+    if (file.buffer) {
+      await fs.writeFile(destPath, file.buffer);
+    } else if (file.path) {
+      // multer's diskStorage already wrote the file; move it into our
+      // managed logos directory so the URL below is guaranteed to resolve.
+      await fs.rename(file.path, destPath);
+    } else {
+      throw new Error('Uploaded file has neither a buffer nor a path');
+    }
+
+    return `/uploads/logos/${fileName}`;
   }
 }


### PR DESCRIPTION
## Summary
- Require superadmin auth on `backup` and `admin/tenants/analytics` controllers — previously callable by anyone with no token.
- Verify M-Pesa STK callbacks with a per-tenant HMAC token embedded in the registered `CallBackURL` (Safaricom does not sign callbacks); require auth + tenant ownership on `/mpesa/initiate`, `/mpesa/status/:id`, `/mpesa/transaction/:id`.
- Implement real backup restore (`pg_restore`) and streamed download, replacing a rejected stub and a JSON-path response respectively.
- Implement the five bulk admin actions that previously threw "not yet implemented": `reset_passwords`, `update_plan`, `export_data`, `import_data`, `optimize_database`.
- Replace the dead `console.log` queue placeholder with a real retrying in-process job queue; wire `EmailService` through it so SMTP calls no longer block the request path. Fixes a related latent bug where an ad-hoc `new EmailService()` would hijack the shared queue's handler.
- Wire the already-existing `SubscriptionService.canAddProduct` check into product creation (users/branches/sales already had it, products did not). Correct a misleading placeholder comment in `subscription.guard.ts`, which turned out to be dead code superseded by JwtStrategy-level enforcement.
- Persist tenant logo uploads to disk instead of returning a fake URL.
- Implement 5 of the 6 missing analytics endpoints (inventory movement, valuation, aging, turnover, product-category-analysis) against real Prisma data. Supplier Performance intentionally left out — no purchase-order/delivery-tracking data exists in the schema to compute it from honestly.
- Document ~25 previously-undocumented required env vars in `.env.example`.

## Test plan
All changes were verified end-to-end against a running instance (not just typecheck/lint) — see verification notes below.

- [x] `tsc --noEmit`: 99 pre-existing errors, unchanged before/after — zero new type errors
- [x] `eslint`: clean on all touched files
- [x] Booted the app against local Postgres; all modules wired with no DI errors
- [x] `GET /backup/status`, `/admin/tenants/analytics`, `POST /mpesa/initiate`, `/mpesa/status/:id`, `/mpesa/transaction/:id` confirmed `401` with no token, `200` with a valid token
- [x] M-Pesa callback confirmed `404` for an unknown checkout ID, `403` for a real transaction with a missing/wrong token, `200` with the correct HMAC token
- [x] All 5 new analytics endpoints return real computed data from Prisma (verified against actual product cost/price)
- [x] `export_data` bulk action confirmed to write a real file matching DB contents; `optimize_database` confirmed to run `VACUUM ANALYZE` successfully
- [x] `GET /backup/download/:filename` confirmed to stream a valid Postgres dump file (`file` command verified)
- [ ] Backup **restore** was not live-tested against this DB (would overwrite real dev data) — needs a disposable database to exercise safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)